### PR TITLE
Mirror GitHub Commits to Codeberg

### DIFF
--- a/.github/workflows/push-to-codeberg.yml
+++ b/.github/workflows/push-to-codeberg.yml
@@ -1,0 +1,15 @@
+name: Push GitHub Commits to Codeberg
+# https://github.com/marketplace/actions/mirror-repository#example-workflows
+on: [push]
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: yesolutions/mirror-action@18fc60c
+      with:
+        REMOTE: 'ssh://git@github.com/SpiderGlider/sm3tools.git'
+        GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
+        GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}

--- a/.github/workflows/push-to-codeberg.yml
+++ b/.github/workflows/push-to-codeberg.yml
@@ -10,6 +10,6 @@ jobs:
         fetch-depth: 0
     - uses: yesolutions/mirror-action@18fc60c0629185af960c8256ccb650287a350b4e
       with:
-        REMOTE: 'ssh://git@github.com/SpiderGlider/sm3tools.git'
+        REMOTE: 'ssh://git@codeberg.org/SpiderGlider/sm3tools.git'
         GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
         GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}

--- a/.github/workflows/push-to-codeberg.yml
+++ b/.github/workflows/push-to-codeberg.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: yesolutions/mirror-action@18fc60c
+    - uses: yesolutions/mirror-action@18fc60c0629185af960c8256ccb650287a350b4e
       with:
         REMOTE: 'ssh://git@github.com/SpiderGlider/sm3tools.git'
         GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}

--- a/.github/workflows/push-to-codeberg.yml
+++ b/.github/workflows/push-to-codeberg.yml
@@ -12,4 +12,7 @@ jobs:
       with:
         REMOTE: 'ssh://git@codeberg.org/SpiderGlider/sm3tools.git'
         GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
-        GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}
+        # verifying is broken?
+        # https://github.com/yesolutions/mirror-action/issues/14
+        GIT_SSH_NO_VERIFY_HOST: "true"
+        #GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}


### PR DESCRIPTION
Unfortunately, the action used seems to be broken when it comes to verifying the host, but hopefully it isn't too big of an issue.

